### PR TITLE
Snoop filter by type

### DIFF
--- a/cli/lifx-snoop/lifx-snoop.go
+++ b/cli/lifx-snoop/lifx-snoop.go
@@ -5,11 +5,18 @@ import (
 	"fmt"
 	"github.com/bjeanes/go-lifx/protocol"
 	"github.com/fatih/color"
+	"os"
 	"regexp"
 	"strings"
 )
 
 func main() {
+	filter := ""
+
+	if len(os.Args) >= 2 {
+		filter = strings.ToLower(os.Args[1])
+	}
+
 	conn, err := protocol.Connect()
 
 	if err != nil {
@@ -31,26 +38,36 @@ func main() {
 
 	msgs, errs := protocol.NewMessageDecoder(decoderDatagrams)
 
-	re := regexp.MustCompilePOSIX("^00000")
-
 	for {
 		d := <-snoopDatagrams
 
 		out := color.New(color.FgWhite)
-		out.Printf("FROM: %s\n", d.From)
-		out.Printf("SIZE: %d\n", len(d.Data))
-		data := strings.TrimLeft(hex.Dump(d.Data), "0")
-		out.Printf("DATA: 000" + re.ReplaceAllString(data, "      "))
-		color.Set(color.Bold)
 
 		select {
 		case msg := <-msgs:
+			t := strings.ToLower(fmt.Sprintf("%T", msg.Payload))
+			if !strings.Contains(t, filter) {
+				break
+			}
+			printDatagram(out, &d)
 			out.Add(color.FgGreen)
 			out.Printf("MSG:  %+v\n      %T %+v", msg.Header, msg.Payload, msg.Payload)
+			fmt.Printf("\n\n")
 		case err := <-errs:
+			printDatagram(out, &d)
 			out.Add(color.FgRed)
 			out.Printf("ERR:  %s", err.Error())
+			fmt.Printf("\n\n")
 		}
-		fmt.Printf("\n\n")
 	}
+}
+
+func printDatagram(out *color.Color, d *protocol.Datagram) {
+	re := regexp.MustCompilePOSIX("^00000")
+
+	out.Printf("FROM: %s\n", d.From)
+	out.Printf("SIZE: %d\n", len(d.Data))
+	data := strings.TrimLeft(hex.Dump(d.Data), "0")
+	out.Printf("DATA: 000" + re.ReplaceAllString(data, "      "))
+	color.Set(color.Bold)
 }

--- a/cli/lifx-snoop/lifx-snoop.go
+++ b/cli/lifx-snoop/lifx-snoop.go
@@ -6,6 +6,7 @@ import (
 	"github.com/bjeanes/go-lifx/protocol"
 	"github.com/fatih/color"
 	"regexp"
+	"strings"
 )
 
 func main() {
@@ -36,8 +37,10 @@ func main() {
 		d := <-snoopDatagrams
 
 		out := color.New(color.FgWhite)
-		out.Printf("DATA: length=%d\n", len(d.Data))
-		out.Print(re.ReplaceAllString(hex.Dump(d.Data), "      "))
+		out.Printf("FROM: %s\n", d.From)
+		out.Printf("SIZE: %d\n", len(d.Data))
+		data := strings.TrimLeft(hex.Dump(d.Data), "0")
+		out.Printf("DATA: 000" + re.ReplaceAllString(data, "      "))
 		color.Set(color.Bold)
 
 		select {


### PR DESCRIPTION
This PR really includes two changes:
1. Printing out the IP address of the messages:
   
   ```
   FROM: 192.168.11.33:56700
   SIZE: 88
   DATA: 000  58 00 00 54 00 00 00 00  d0 73 d5 00 0c af 00 00  |X..T.....s......|
         010  4c 49 46 58 56 32 00 00  00 00 00 00 00 00 00 00  |LIFXV2..........|
         020  6b 00 00 00 0a 16 32 33  ff ff ac 0d 00 00 ff ff  |k.....23........|
         030  f0 9f 94 ad 00 00 00 00  00 00 00 00 00 00 00 00  |................|
         040  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
         050  01 00 00 00 00 00 00 00                           |........|
   MSG:  &{Version:1024 Target:[208 115 213 0 12 175 0 0] Site:[76 73 70 88 86 50] AtTime:0 Addressable:true Tagged:false Acknowledge:false}
         *payloads.LightState &{Color:{Hue:5642 Saturation:13106 Brightness:65535 Kelvin:3500} Dim:0 Power:65535 Label:🔭 Tags:1}
   ```
2. Optionally, filtering by payload type:
   
   ``` sh-session
   $ go run cli/lifx-snoop/lifx-snoop.go pan # where "pan" is the case-insensitive filter on payload name
   FROM: 192.168.11.52:56700
   SIZE: 36
   DATA: 000  24 00 00 34 00 00 00 00  00 00 00 00 00 00 00 00  |$..4............|
         010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
         020  02 00 00 00                                       |....|
   MSG:  &{Version:1024 Target:[0 0 0 0 0 0 0 0] Site:[0 0 0 0 0 0] AtTime:0 Addressable:true Tagged:true Acknowledge:false}
         *payloads.DeviceGetPanGateway &{}
   
   FROM: 192.168.11.33:56700
   SIZE: 41
   DATA: 000  29 00 00 54 00 00 00 00  d0 73 d5 00 03 c4 00 00  |)..T.....s......|
         010  4c 49 46 58 56 32 00 00  00 00 00 00 00 00 00 00  |LIFXV2..........|
         020  03 00 00 00 01 7c dd 00  00                       |.....|...|
   MSG:  &{Version:1024 Target:[208 115 213 0 3 196 0 0] Site:[76 73 70 88 86 50] AtTime:0 Addressable:true Tagged:false Acknowledge:false}
         *payloads.DeviceStatePanGateway &{Service:1 Port:56700}
   $ go run cli/lifx-snoop/lifx-snoop.go lightget
   FROM: 192.168.11.52:56750
   SIZE: 36
   DATA: 000  24 00 00 34 00 00 00 00  00 00 00 00 00 00 00 00  |$..4............|
         010  4c 49 46 58 56 32 00 00  00 00 00 00 00 00 00 00  |LIFXV2..........|
         020  65 00 00 00                                       |e...|
   MSG:  &{Version:1024 Target:[0 0 0 0 0 0 0 0] Site:[76 73 70 88 86 50] AtTime:0 Addressable:true Tagged:true Acknowledge:false}
         *payloads.LightGet &{}
   
   FROM: 192.168.11.52:56750
   SIZE: 36
   DATA: 000  24 00 00 34 00 00 00 00  00 00 00 00 00 00 00 00  |$..4............|
         010  4c 49 46 58 56 32 00 00  00 00 00 00 00 00 00 00  |LIFXV2..........|
         020  65 00 00 00                                       |e...|
   MSG:  &{Version:1024 Target:[0 0 0 0 0 0 0 0] Site:[76 73 70 88 86 50] AtTime:0 Addressable:true Tagged:true Acknowledge:false}
         *payloads.LightGet &{}
   ```
