### PR TITLE
Format Site fields (e.g. when snooping)

### DIFF
--- a/protocol/header.go
+++ b/protocol/header.go
@@ -1,5 +1,7 @@
 package protocol
 
+import "github.com/bjeanes/go-lifx/protocol/payloads"
+
 type (
 	bitfield uint16
 
@@ -14,7 +16,7 @@ type (
 
 		_      uint32 // <reserved>
 		Target [8]byte
-		Site   [6]byte
+		Site   payloads.Site
 
 		// 1 bit = acknowledge bool
 		// 15 bits = <reserved>
@@ -29,7 +31,7 @@ type (
 	Header struct {
 		Version     uint16
 		Target      [8]byte
-		Site        [6]byte
+		Site        payloads.Site
 		AtTime      uint64
 		Addressable bool
 		Tagged      bool

--- a/protocol/payloads/types.go
+++ b/protocol/payloads/types.go
@@ -6,9 +6,9 @@ type Payload interface {
 	Id() uint16
 }
 
-type site [6]byte
+type Site [6]byte
 
-func (site site) String() string {
+func (site Site) String() string {
 	bytes := [6]byte(site)
 	return strings.Trim(string(bytes[:]), "\x00")
 }
@@ -34,7 +34,7 @@ type LightHsbk struct {
 }
 
 type DeviceSetSite struct {
-	Site site
+	Site Site
 }
 
 type DeviceGetPanGateway struct{}
@@ -221,19 +221,19 @@ type WanStateConnect struct {
 
 type WanSub struct {
 	Target [8]byte
-	Site   site
+	Site   Site
 	Device uint8 // 0 device; 1 tag
 }
 
 type WanUnsub struct {
 	Target [8]byte
-	Site   site
+	Site   Site
 	Device uint8 // 0 device; 1 tag
 }
 
 type WanStateSub struct {
 	Target [8]byte
-	Site   site
+	Site   Site
 	Device uint8 // 0 device; 1 tag
 }
 


### PR DESCRIPTION
``` sh-session
$ lifx-snoop
DATA: length=88
      000  58 00 00 54 00 00 00 00  d0 73 d5 00 fb b0 00 00  |X..T.....s......|
      010  4c 49 46 58 56 32 00 00  00 00 00 00 00 00 00 00  |LIFXV2..........|
      020  6b 00 00 00 0a 16 32 33  ff ff ac 0d 00 00 ff ff  |k.....23........|
      030  f0 9f 93 9a 00 00 00 00  00 00 00 00 00 00 00 00  |................|
      040  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
      050  01 00 00 00 00 00 00 00                           |........|
MSG:  &{Version:1024 Target:[208 115 213 0 251 176 0 0] Site:LIFXV2 AtTime:0 Addressable:true Tagged:false Acknowledge:false}
      *payloads.LightState &{Color:{Hue:5642 Saturation:13106 Brightness:65535 Kelvin:3500} Dim:0 Power:65535 Label:📚 Tags:1}
```

Note the `Site:LIFXV2` instead of opaque byte array.
