### PR TITLE
Merge payloads package into protocol package

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	proto "github.com/bjeanes/go-lifx/protocol"
-	payloads "github.com/bjeanes/go-lifx/protocol/payloads"
 	"time"
 )
 
@@ -30,7 +29,7 @@ func New() *client {
 	return c
 }
 
-func (c *client) SendMessage(payload payloads.Payload) (data []byte, error error) {
+func (c *client) SendMessage(payload proto.Payload) (data []byte, error error) {
 	msg := proto.Message{}
 	msg.Payload = payload
 
@@ -44,7 +43,7 @@ func (c *client) Discover() <-chan *light {
 	go func() {
 		timeout := time.After(5 * time.Second)
 
-		c.SendMessage(payloads.LightGet{})
+		c.SendMessage(proto.LightGet{})
 
 		for {
 			select {
@@ -52,9 +51,9 @@ func (c *client) Discover() <-chan *light {
 				close(ch)
 			case msg := <-c.Messages:
 				switch payload := msg.Payload.(type) {
-				case *payloads.DeviceStatePanGateway:
+				case *proto.DeviceStatePanGateway:
 					// TODO: record gateway devices
-				case *payloads.LightState:
+				case *proto.LightState:
 					ch <- c.Lights.Register(payload)
 				default:
 					// nada

--- a/client/light.go
+++ b/client/light.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/bjeanes/go-lifx/protocol/payloads"
+	proto "github.com/bjeanes/go-lifx/protocol"
 )
 
 type lightCollection struct {
@@ -9,7 +9,7 @@ type lightCollection struct {
 	lights []light
 }
 
-func (lc *lightCollection) Register(state *payloads.LightState) *light {
+func (lc *lightCollection) Register(state *proto.LightState) *light {
 	light := light{client: lc.client}
 	light.UpdateFromState(state)
 	lc.lights = append(lc.lights, light)
@@ -26,21 +26,21 @@ func (lc *lightCollection) All() []light {
 
 type light struct {
 	*client
-	state *payloads.LightState
+	state *proto.LightState
 }
 
 func (l *light) Label() string {
 	return l.state.Label.String()
 }
 
-func (l *light) UpdateFromState(state *payloads.LightState) {
+func (l *light) UpdateFromState(state *proto.LightState) {
 	l.state = state
 }
 
 func (l light) TurnOff() {
-	l.client.SendMessage(payloads.DeviceSetPower{Level: 0})
+	l.client.SendMessage(proto.DeviceSetPower{Level: 0})
 }
 
 func (l light) TurnOn() {
-	l.client.SendMessage(payloads.DeviceSetPower{Level: 1})
+	l.client.SendMessage(proto.DeviceSetPower{Level: 1})
 }

--- a/protocol/constants.go
+++ b/protocol/constants.go
@@ -1,4 +1,4 @@
-package payloads
+package protocol
 
 const (
 	_ ifaceType = iota

--- a/protocol/header.go
+++ b/protocol/header.go
@@ -1,7 +1,5 @@
 package protocol
 
-import "github.com/bjeanes/go-lifx/protocol/payloads"
-
 type (
 	bitfield uint16
 
@@ -16,7 +14,7 @@ type (
 
 		_      uint32 // <reserved>
 		Target [8]byte
-		Site   payloads.Site
+		Site   Site
 
 		// 1 bit = acknowledge bool
 		// 15 bits = <reserved>
@@ -31,7 +29,7 @@ type (
 	Header struct {
 		Version     uint16
 		Target      [8]byte
-		Site        payloads.Site
+		Site        Site
 		AtTime      uint64
 		Addressable bool
 		Tagged      bool

--- a/protocol/ids.go
+++ b/protocol/ids.go
@@ -1,4 +1,4 @@
-package payloads
+package protocol
 
 const (
 	DeviceSetSiteID             uint16 = 1

--- a/protocol/message.go
+++ b/protocol/message.go
@@ -5,8 +5,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/bjeanes/go-lifx/protocol/payloads"
-	// "strings"
 )
 
 const compatibleVersion = 1024
@@ -14,7 +12,7 @@ const headerSize = 36
 
 type Message struct {
 	*Header
-	payloads.Payload
+	Payload
 }
 
 // http://golang.org/pkg/encoding/#BinaryUnmarshaler
@@ -32,7 +30,7 @@ func (msg *Message) UnmarshalBinary(data []byte) error {
 		return errors.New(fmt.Sprintf("Unknown message version (%d)", v))
 	}
 
-	payload := payloads.ForId(msgHeader.Type)
+	payload := ForId(msgHeader.Type)
 	if payload != nil {
 		if reader.Len() != binary.Size(payload) {
 			return errors.New(fmt.Sprintf("Unexpected payload size for %T", payload))

--- a/protocol/message_test.go
+++ b/protocol/message_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"github.com/bjeanes/go-lifx/protocol/payloads"
 	. "testing"
 )
 
@@ -87,7 +86,7 @@ func TestDecodeDeviceStatePanGatewayService1(t *T) {
 		t.Error("Site incorrect")
 	}
 
-	payload := msg.Payload.(*payloads.DeviceStatePanGateway)
+	payload := msg.Payload.(*DeviceStatePanGateway)
 
 	if payload.Service != 1 {
 		t.Error("Service incorrect")
@@ -144,7 +143,7 @@ func TestDecodeDeviceStatePanGatewayService2(t *T) {
 		t.Error("Site incorrect")
 	}
 
-	payload := msg.Payload.(*payloads.DeviceStatePanGateway)
+	payload := msg.Payload.(*DeviceStatePanGateway)
 
 	if payload.Service != 2 {
 		t.Error("Service incorrect")
@@ -164,7 +163,7 @@ func TestDecodeLightState(t *T) {
 	//       040  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
 	//       050  01 00 00 00 00 00 00 00                           |........|
 	// MSG:  &{version:1024 target:[208 115 213 0 249 20 0 0] site:[76 73 70 88 86 50] atTime:0 addressable:true tagged:false acknowledge:false}
-	//       *payloads.LightState &{Color:{Hue:0 Saturation:0 Brightness:15994 Kelvin:2500} Dim:0 Power:0 Label:Bedroom Tags:1}
+	//       *protocol.LightState &{Color:{Hue:0 Saturation:0 Brightness:15994 Kelvin:2500} Dim:0 Power:0 Label:Bedroom Tags:1}
 
 	b := []byte{
 		0x58, 0x00, 0x00, 0x54, 0x00, 0x00, 0x00, 0x00,
@@ -213,8 +212,8 @@ func TestDecodeLightState(t *T) {
 		t.Error("Site incorrect")
 	}
 
-	payload := msg.Payload.(*payloads.LightState)
-	// *payloads.LightState &{Color:{Hue:0 Saturation:0 Brightness:15994 Kelvin:2500} Dim:0 Power:0 Label:Bedroom Tags:1}
+	payload := msg.Payload.(*LightState)
+	// *LightState &{Color:{Hue:0 Saturation:0 Brightness:15994 Kelvin:2500} Dim:0 Power:0 Label:Bedroom Tags:1}
 
 	if payload.Color.Hue != 0 {
 		t.Error("Hue incorrect")
@@ -256,7 +255,7 @@ func TestDeviceSetPowerOn(t *T) {
 	//       010  4c 49 46 58 56 32 00 00  00 00 00 00 00 00 00 00  |LIFXV2..........|
 	//       020  15 00 00 00 01 00                                 |......|
 	// MSG:  &{Version:1024 Target:[0 0 0 0 0 0 0 0] Site:[76 73 70 88 86 50] AtTime:0 Addressable:true Tagged:true Acknowledge:false}
-	//       *payloads.DeviceSetPower &{Level:1}
+	//       *protocol.DeviceSetPower &{Level:1}
 
 	b := []byte{
 		0x26, 0x00, 0x00, 0x34, 0x00, 0x00, 0x00, 0x00,
@@ -274,7 +273,7 @@ func TestDeviceSetPowerOn(t *T) {
 		t.Error("Decode failed with err: " + err.Error())
 	}
 
-	payload := msg.Payload.(*payloads.DeviceSetPower)
+	payload := msg.Payload.(*DeviceSetPower)
 
 	if payload.Level != 1 {
 		t.Error("Level incorrect")
@@ -287,7 +286,7 @@ func TestDeviceSetPowerOff(t *T) {
 	//       010  4c 49 46 58 56 32 00 00  00 00 00 00 00 00 00 00  |LIFXV2..........|
 	//       020  15 00 00 00 00 00                                 |......|
 	// MSG:  &{version:1024 target:[208 115 213 0 249 20 0 0] site:[76 73 70 88 86 50] atTime:0 addressable:true tagged:false acknowledge:false}
-	//       *payloads.DeviceSetPower &{Level:0}
+	//       *protocol.DeviceSetPower &{Level:0}
 
 	b := []byte{
 		0x26, 0x00, 0x00, 0x54, 0x00, 0x00, 0x00, 0x00,
@@ -305,7 +304,7 @@ func TestDeviceSetPowerOff(t *T) {
 		t.Error("Decode failed with err: " + err.Error())
 	}
 
-	payload := msg.Payload.(*payloads.DeviceSetPower)
+	payload := msg.Payload.(*DeviceSetPower)
 
 	if payload.Level != 0 {
 		t.Error("Level incorrect")
@@ -318,7 +317,7 @@ func TestDecodeDeviceStatePower(t *T) {
 	//       010  4c 49 46 58 56 32 00 00  00 00 00 00 00 00 00 00  |LIFXV2..........|
 	//       020  16 00 00 00 00 00                                 |......|
 	// MSG:  &{version:1024 target:[208 115 213 0 249 20 0 0] site:[76 73 70 88 86 50] atTime:0 addressable:true tagged:false acknowledge:false}
-	//       *payloads.DeviceStatePower &{Level:65535}
+	//       *protocol.DeviceStatePower &{Level:65535}
 
 	b := []byte{
 		0x26, 0x00, 0x00, 0x54, 0x00, 0x00, 0x00, 0x00,
@@ -358,7 +357,7 @@ func TestDecodeDeviceStatePower(t *T) {
 		t.Error("Site incorrect")
 	}
 
-	payload := msg.Payload.(*payloads.DeviceStatePower)
+	payload := msg.Payload.(*DeviceStatePower)
 
 	if payload.Level != 65535 {
 		t.Error("Power level incorrect")
@@ -411,7 +410,7 @@ func TestMarshalBinary(t *T) {
 		Acknowledge: false,
 	}
 	msg.Header = &header
-	msg.Payload = payloads.DeviceGetPanGateway{}
+	msg.Payload = DeviceGetPanGateway{}
 
 	data, err := msg.MarshalBinary()
 	if err != nil {
@@ -462,7 +461,7 @@ func TestTaggedMarshalBinary(t *T) {
 		Acknowledge: false,
 	}
 	msg.Header = &header
-	msg.Payload = payloads.DeviceGetPanGateway{}
+	msg.Payload = DeviceGetPanGateway{}
 
 	data, err := msg.MarshalBinary()
 	if err != nil {
@@ -513,7 +512,7 @@ func TestDeviceSetPowerOnMarshalBinary(t *T) {
 		Acknowledge: false,
 	}
 	msg.Header = &header
-	msg.Payload = payloads.DeviceSetPower{Level: 1}
+	msg.Payload = DeviceSetPower{Level: 1}
 
 	data, err := msg.MarshalBinary()
 	if err != nil {

--- a/protocol/payloads.go
+++ b/protocol/payloads.go
@@ -1,36 +1,7 @@
-package payloads
-
-import "strings"
+package protocol
 
 type Payload interface {
 	Id() uint16
-}
-
-type Site [6]byte
-
-func (site Site) String() string {
-	bytes := [6]byte(site)
-	return strings.Trim(string(bytes[:]), "\x00")
-}
-
-type label [32]byte
-
-func (label label) String() string {
-	bytes := [32]byte(label)
-	return strings.Trim(string(bytes[:]), "\x00")
-}
-
-type (
-	apSecurity uint8
-	ifaceType  uint8
-	wifiStatus uint8
-)
-
-type LightHsbk struct {
-	Hue        uint16 // 0-65535 scaled to 0-360°
-	Saturation uint16 // 0-65535 scaled to 0-100%
-	Brightness uint16 // 0-65535 scaled to 0-100%
-	Kelvin     uint16 // absolute 2400-10000
 }
 
 type DeviceSetSite struct {
@@ -158,14 +129,14 @@ type LightGet struct{}
 
 type LightSet struct {
 	Stream   uint8
-	Color    LightHsbk
+	Color    Hsbk
 	Duration uint32 // ms
 }
 
 type LightSetWaveform struct {
 	Stream    uint8
 	Transient uint8 // 0 false; 1+ true
-	Color     LightHsbk
+	Color     Hsbk
 	Period    uint32 // ms per cycle
 	DutyCycle int16
 	Waveform  uint8
@@ -188,7 +159,7 @@ type LightSetRgbw struct {
 }
 
 type LightState struct {
-	Color LightHsbk
+	Color Hsbk
 	Dim   int16
 	Power uint16
 	Label label

--- a/protocol/types.go
+++ b/protocol/types.go
@@ -1,0 +1,30 @@
+package protocol
+
+import "strings"
+
+type Site [6]byte
+
+func (site Site) String() string {
+	bytes := [6]byte(site)
+	return strings.Trim(string(bytes[:]), "\x00")
+}
+
+type label [32]byte
+
+func (label label) String() string {
+	bytes := [32]byte(label)
+	return strings.Trim(string(bytes[:]), "\x00")
+}
+
+type (
+	apSecurity uint8
+	ifaceType  uint8
+	wifiStatus uint8
+)
+
+type Hsbk struct {
+	Hue        uint16 // 0-65535 scaled to 0-360°
+	Saturation uint16 // 0-65535 scaled to 0-100%
+	Brightness uint16 // 0-65535 scaled to 0-100%
+	Kelvin     uint16 // absolute 2400-10000
+}


### PR DESCRIPTION
I was trying to subdivide too early because but in Go, the visibility rules and
general community comfort with larger packages probably means having an
uber-protocol package is better -- for now.

This is mostly an FYI since I'm going to merge it pretty quickly in order to keep working on stuff. 
