### PR TITLE
Add missing documented packet types, add "unknown" types to catch common but unknown packets, add ip address "from" to messages

### DIFF
--- a/protocol/ids.go
+++ b/protocol/ids.go
@@ -36,6 +36,13 @@ const (
 	DeviceGetMcuRailVoltageID          = 36
 	DeviceStateMcuRailVoltageID        = 37
 	DeviceRebootID                     = 38
+	DeviceAcknowledgementID            = 45
+	DeviceGetLocationID                = 48
+	DeviceStateLocationID              = 50
+	DeviceGetGroupID                   = 51
+	DeviceStateGroupID                 = 53
+	DeviceEchoRequestID                = 58
+	DeviceEchoResponseID               = 59
 	LightGetID                         = 101
 	LightSetID                         = 102
 	LightSetWaveformID                 = 103
@@ -47,6 +54,9 @@ const (
 	LightStateRailVoltageID            = 109
 	LightGetTemperatureID              = 110
 	LightStateTemperatureID            = 111
+	LightGetPowerID                    = 116
+	LightSetPowerID                    = 117
+	LightStatePowerID                  = 118
 	WanConnectPlainID                  = 201
 	WanConnectKeyID                    = 202
 	WanStateConnectID                  = 203
@@ -137,6 +147,20 @@ func ForId(id uint16) Payload {
 		return new(DeviceStateMcuRailVoltage)
 	case DeviceRebootID:
 		return new(DeviceReboot)
+	case DeviceAcknowledgementID:
+		return new(DeviceAcknowledgement)
+	case DeviceGetLocationID:
+		return new(DeviceGetLocation)
+	case DeviceStateLocationID:
+		return new(DeviceStateLocation)
+	case DeviceGetGroupID:
+		return new(DeviceGetGroup)
+	case DeviceStateGroupID:
+		return new(DeviceStateGroup)
+	case DeviceEchoRequestID:
+		return new(DeviceEchoRequest)
+	case DeviceEchoResponseID:
+		return new(DeviceEchoResponse)
 	case LightGetID:
 		return new(LightGet)
 	case LightSetID:
@@ -159,6 +183,12 @@ func ForId(id uint16) Payload {
 		return new(LightGetTemperature)
 	case LightStateTemperatureID:
 		return new(LightStateTemperature)
+	case LightGetPowerID:
+		return new(LightGetPower)
+	case LightSetPowerID:
+		return new(LightSetPower)
+	case LightStatePowerID:
+		return new(LightStatePower)
 	case WanConnectPlainID:
 		return new(WanConnectPlain)
 	case WanConnectKeyID:
@@ -231,6 +261,13 @@ func (DeviceStateInfo) Id() uint16           { return DeviceStateInfoID }
 func (DeviceGetMcuRailVoltage) Id() uint16   { return DeviceGetMcuRailVoltageID }
 func (DeviceStateMcuRailVoltage) Id() uint16 { return DeviceStateMcuRailVoltageID }
 func (DeviceReboot) Id() uint16              { return DeviceRebootID }
+func (DeviceAcknowledgement) Id() uint16     { return DeviceAcknowledgementID }
+func (DeviceGetLocation) Id() uint16         { return DeviceGetLocationID }
+func (DeviceStateLocation) Id() uint16       { return DeviceStateLocationID }
+func (DeviceGetGroup) Id() uint16            { return DeviceGetGroupID }
+func (DeviceStateGroup) Id() uint16          { return DeviceStateGroupID }
+func (DeviceEchoRequest) Id() uint16         { return DeviceEchoRequestID }
+func (DeviceEchoResponse) Id() uint16        { return DeviceEchoResponseID }
 func (LightGet) Id() uint16                  { return LightGetID }
 func (LightSet) Id() uint16                  { return LightSetID }
 func (LightSetWaveform) Id() uint16          { return LightSetWaveformID }
@@ -242,6 +279,9 @@ func (LightGetRailVoltage) Id() uint16       { return LightGetRailVoltageID }
 func (LightStateRailVoltage) Id() uint16     { return LightStateRailVoltageID }
 func (LightGetTemperature) Id() uint16       { return LightGetTemperatureID }
 func (LightStateTemperature) Id() uint16     { return LightStateTemperatureID }
+func (LightGetPower) Id() uint16             { return LightGetPowerID }
+func (LightSetPower) Id() uint16             { return LightSetPowerID }
+func (LightStatePower) Id() uint16           { return LightStatePowerID }
 func (WanConnectPlain) Id() uint16           { return WanConnectPlainID }
 func (WanConnectKey) Id() uint16             { return WanConnectKeyID }
 func (WanStateConnect) Id() uint16           { return WanStateConnectID }

--- a/protocol/ids.go
+++ b/protocol/ids.go
@@ -41,6 +41,7 @@ const (
 	DeviceStateLocationID              = 50
 	DeviceGetGroupID                   = 51
 	DeviceStateGroupID                 = 53
+	Unknown54ID                        = 54 // Unsure as to what this packet type is...
 	DeviceEchoRequestID                = 58
 	DeviceEchoResponseID               = 59
 	LightGetID                         = 101
@@ -158,6 +159,8 @@ func ForId(id uint16) Payload {
 		return new(DeviceGetGroup)
 	case DeviceStateGroupID:
 		return new(DeviceStateGroup)
+	case Unknown54ID:
+		return new(Unknown54)
 	case DeviceEchoRequestID:
 		return new(DeviceEchoRequest)
 	case DeviceEchoResponseID:
@@ -269,6 +272,7 @@ func (DeviceGetLocation) Id() uint16         { return DeviceGetLocationID }
 func (DeviceStateLocation) Id() uint16       { return DeviceStateLocationID }
 func (DeviceGetGroup) Id() uint16            { return DeviceGetGroupID }
 func (DeviceStateGroup) Id() uint16          { return DeviceStateGroupID }
+func (Unknown54) Id() uint16                 { return Unknown54ID }
 func (DeviceEchoRequest) Id() uint16         { return DeviceEchoRequestID }
 func (DeviceEchoResponse) Id() uint16        { return DeviceEchoResponseID }
 func (LightGet) Id() uint16                  { return LightGetID }

--- a/protocol/ids.go
+++ b/protocol/ids.go
@@ -73,6 +73,7 @@ const (
 	SensorStateAmbientLightID          = 402
 	SensorGetDimmerVoltageID           = 403
 	SensorStateDimmerVoltageID         = 404
+	Unknown406ID                       = 406 // Appears to be related to updating cloud with status. (https://community.lifx.com/t/using-the-source-and-target-fields-in-the-lan-protocol/124/3)
 )
 
 func ForId(id uint16) Payload {
@@ -221,6 +222,8 @@ func ForId(id uint16) Payload {
 		return new(SensorGetDimmerVoltage)
 	case SensorStateDimmerVoltageID:
 		return new(SensorStateDimmerVoltage)
+	case Unknown406ID:
+		return new(Unknown406)
 	default:
 		return nil
 	}
@@ -298,3 +301,4 @@ func (SensorGetAmbientLight) Id() uint16     { return SensorGetAmbientLightID }
 func (SensorStateAmbientLight) Id() uint16   { return SensorStateAmbientLightID }
 func (SensorGetDimmerVoltage) Id() uint16    { return SensorGetDimmerVoltageID }
 func (SensorStateDimmerVoltage) Id() uint16  { return SensorStateDimmerVoltageID }
+func (Unknown406) Id() uint16                { return Unknown406ID }

--- a/protocol/payloads.go
+++ b/protocol/payloads.go
@@ -125,6 +125,32 @@ type DeviceStateMcuRailVoltage struct {
 
 type DeviceReboot struct{}
 
+type DeviceAcknowledgement struct{}
+
+type DeviceGetLocation struct{}
+
+type DeviceStateLocation struct {
+	Location  group
+	Label     label
+	UpdatedAt uint64
+}
+
+type DeviceGetGroup struct{}
+
+type DeviceStateGroup struct {
+	Group     group
+	Label     label
+	UpdatedAt uint64
+}
+
+type DeviceEchoRequest struct {
+	Payload echoPayload
+}
+
+type DeviceEchoResponse struct {
+	Payload echoPayload
+}
+
 type LightGet struct{}
 
 type LightSet struct {
@@ -176,6 +202,17 @@ type LightGetTemperature struct{}
 
 type LightStateTemperature struct {
 	Temperature int16 // deci-celsius
+}
+
+type LightGetPower struct{}
+
+type LightSetPower struct {
+	Level    uint16
+	Duration uint32
+}
+
+type LightStatePower struct {
+	Level uint16
 }
 
 type WanConnectPlain struct {

--- a/protocol/payloads.go
+++ b/protocol/payloads.go
@@ -289,3 +289,8 @@ type SensorGetDimmerVoltage struct{}
 type SensorStateDimmerVoltage struct {
 	Voltage uint32
 }
+
+// Appears to be related to updating cloud with status. (https://community.lifx.com/t/using-the-source-and-target-fields-in-the-lan-protocol/124/3)
+type Unknown406 struct {
+	Data [4]byte // Unsure what the datatype of this payload is, or what it's meaning is, so we'll leave it as raw bytes
+}

--- a/protocol/payloads.go
+++ b/protocol/payloads.go
@@ -143,6 +143,8 @@ type DeviceStateGroup struct {
 	UpdatedAt uint64
 }
 
+type Unknown54 struct{}
+
 type DeviceEchoRequest struct {
 	Payload echoPayload
 }

--- a/protocol/types.go
+++ b/protocol/types.go
@@ -20,6 +20,20 @@ func (label label) String() string {
 	return strings.Trim(string(bytes[:]), "\x00")
 }
 
+type group [16]byte
+
+func (group group) String() string {
+	bytes := [16]byte(group)
+	return strings.Trim(string(bytes[:]), "\x00")
+}
+
+type echoPayload [64]byte
+
+func (ep echoPayload) String() string {
+	bytes := [64]byte(ep)
+	return strings.Trim(string(bytes[:]), "\x00")
+}
+
 type (
 	apSecurity uint8
 	ifaceType  uint8


### PR DESCRIPTION
Initially I forked this to simply add the missing types that are documented on the lifx API docs, but I've added a couple of other things which are useful to a project I'm working on, but are probably also useful in general.

The only thing I haven't added to keep things up to spec is tests for the new packet types. (Happy to figure that out if it blocks merging and you want this PR. Or I can submit a second PR when I get to it.)
